### PR TITLE
improve shell scripts

### DIFF
--- a/contrib/freeze.sh
+++ b/contrib/freeze.sh
@@ -6,5 +6,5 @@ fi
 if [ ! -f "$1" ] ; then echo \"$1\" is not a regular file\! ; exit 1 ; fi
 # stat -c doesn't work under OS/X
 # SIZE=`stat -c '%s' "$1"`
-SIZE=`/bin/ls -l "$1" | awk '{print $5}'`
-( echo MAGIC_TTSIOD_RS ; echo $SIZE ; cat "$1" ) | rsbep -B 255 -D 223 -R 4080
+SIZE=`ls -l "$1" | awk '{print $5}'`
+{ echo MAGIC_TTSIOD_RS ; echo $SIZE ; cat "$1"; } | rsbep -B 255 -D 223 -R 4080

--- a/contrib/melt.sh
+++ b/contrib/melt.sh
@@ -4,10 +4,13 @@ if [ $# -ne 1 ] ; then
 	exit 1
 fi
 if [ ! -f "$1" ] ; then echo $1 is not a regular file\! ; exit 1 ; fi
-SIG=`dd if="$1" conv=noerror,notrunc 2>/dev/null | rsbep -d -B 255 -D 223 -R 4080 | head -1`
-if [ "$SIG" != "MAGIC_TTSIOD_RS" ] ; then
-	echo "Beyond capacity to correct... Sorry." > /dev/stderr
-	exit 1
-fi
-SIZE=`dd if="$1" conv=noerror,sync 2>/dev/null | rsbep -d -B 255 -D 223 -R 4080 | head -2 | tail -1`
-dd if="$1" conv=noerror,sync 2>/dev/null | rsbep -d -B 255 -D 223 -R 4080 | sed '1,2d' 2>/dev/null | rsbep_chopper $SIZE
+
+dd if="$1" conv=noerror,sync 2>/dev/null | rsbep -d -B 255 -D 223 -R 4080 | {
+	read SIG
+	if [ "$SIG" != "MAGIC_TTSIOD_RS" ] ; then
+		echo "Beyond capacity to correct... Sorry." > /dev/stderr
+		exit 1
+	fi
+	read SIZE
+	rsbep_chopper $SIZE
+}


### PR DESCRIPTION
#### Copy of commit message
```
- melt.sh:
  Read header, size and payload from a single data stream.
  This is much simpler and faster.

- freeze.sh:
  - Use command group instead of subshell which is faster.
  - Remove '/bin' prefix from 'ls'.
    This prefix is also not used for other commands like 'awk'.
    The prefix made this script incompatible with systems that don't
    install coreutils to /bin/.
```

Your latest commit contains an important fix (`sync` instead of `notrunc` for `dd`).
Could you make a new release?